### PR TITLE
Correct error message "error: 'find_if' was not declared in this scope"…

### DIFF
--- a/Sources/options.cpp
+++ b/Sources/options.cpp
@@ -82,6 +82,7 @@ and
 #include <cstring>
 #include <cassert>
 #include <filesystem>
+#include <algorithm>
 
 using namespace std;
 


### PR DESCRIPTION
This error message was observed in options.cpp when compiling FBAE with Clion 2023.2.2 using MinGW with g++ compiler version 13.1.0