### PR TITLE
11 fbae does not compile with apple clang because of jthread

### DIFF
--- a/Sources/AlgoLayer/AlgoLayer.h
+++ b/Sources/AlgoLayer/AlgoLayer.h
@@ -24,7 +24,7 @@ public:
      * @param msgString String containing message.
      * @return true if AckDisconnectIntent message was received and false otherwise
      */
-    virtual bool callbackHandleMessage(std::unique_ptr<CommPeer> peer, const std::string &msgString) = 0;
+    virtual bool callbackHandleMessage(std::unique_ptr<CommPeer> peer, std::string && msgString) = 0;
 
     /**
      * @brief Executes concrete totalOrderBroadcast algorithm. Returns when algorithm is done.

--- a/Sources/AlgoLayer/BBOBBAlgoLayer/BBOBBAlgoLayer.h
+++ b/Sources/AlgoLayer/BBOBBAlgoLayer/BBOBBAlgoLayer.h
@@ -61,7 +61,7 @@ private :
     std::map<int, fbae_BBOBBAlgoLayer::StepMsg> nextWaveReceivedStepMsg;
 
 public :
-    bool callbackHandleMessage(std::unique_ptr<CommPeer> peer, const std::string &msgString) override;
+    bool callbackHandleMessage(std::unique_ptr<CommPeer> peer, std::string && msgString) override;
     bool executeAndProducedStatistics() override;
     void totalOrderBroadcast(std::string && msg) override;
     void terminate() override;

--- a/Sources/AlgoLayer/SequencerAlgoLayer/SequencerAlgoLayer.cpp
+++ b/Sources/AlgoLayer/SequencerAlgoLayer/SequencerAlgoLayer.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <thread>
 #include "../../SessionLayer/SessionLayer.h"
 #include "SequencerAlgoLayer.h"
 #include "SequencerAlgoLayerMsg.h"

--- a/Sources/AlgoLayer/SequencerAlgoLayer/SequencerAlgoLayer.cpp
+++ b/Sources/AlgoLayer/SequencerAlgoLayer/SequencerAlgoLayer.cpp
@@ -8,7 +8,7 @@
 using namespace std;
 using namespace fbae_SequencerAlgoLayer;
 
-bool SequencerAlgoLayer::callbackHandleMessage(std::unique_ptr<CommPeer> peer, const std::string &msgString)
+bool SequencerAlgoLayer::callbackHandleMessage(std::unique_ptr<CommPeer> peer, std::string && msgString)
 {
     auto msgId{ static_cast<MsgId>(msgString[0]) };
     switch (msgId)
@@ -19,7 +19,7 @@ bool SequencerAlgoLayer::callbackHandleMessage(std::unique_ptr<CommPeer> peer, c
         //
         case DisconnectIntent :
         {
-            auto bdi{deserializeStruct<StructDisconnectIntent>(msgString)};
+            auto bdi{deserializeStruct<StructDisconnectIntent>(std::move(msgString))};
             auto s{serializeStruct<StructAckDisconnectIntent>(StructAckDisconnectIntent{MsgId::AckDisconnectIntent})};
             peer->sendMsg(std::move(s));
             if (getSession()->getParam().getVerbose())
@@ -28,7 +28,7 @@ bool SequencerAlgoLayer::callbackHandleMessage(std::unique_ptr<CommPeer> peer, c
         }
         case RankInfo :
         {
-            auto bri{deserializeStruct<StructRankInfo>(msgString)};
+            auto bri{deserializeStruct<StructRankInfo>(std::move(msgString))};
             if (getSession()->getParam().getVerbose())
                 cout << "\tSequencerAlgoLayer / Sequencer : Broadcaster #" << static_cast<uint32_t>(bri.senderRank) << " is connected to sequencer.\n";
             if (++nbConnectedBroadcasters == getBroadcasters().size())
@@ -42,7 +42,7 @@ bool SequencerAlgoLayer::callbackHandleMessage(std::unique_ptr<CommPeer> peer, c
         }
         case MessageToBroadcast :
         {
-            auto msgToBroadcast{deserializeStruct<StructMessageToBroadcast>(msgString)};
+            auto msgToBroadcast{deserializeStruct<StructMessageToBroadcast>(std::move(msgString))};
             auto s {serializeStruct<StructBroadcastMessage>(StructBroadcastMessage{MsgId::BroadcastMessage,
                                                                                    msgToBroadcast.senderRank,
                                                                                    msgToBroadcast.sessionMsg})};
@@ -60,8 +60,8 @@ bool SequencerAlgoLayer::callbackHandleMessage(std::unique_ptr<CommPeer> peer, c
             break;
         case BroadcastMessage :
         {
-            auto sbm {deserializeStruct<StructBroadcastMessage>(msgString)};
-            getSession()->callbackDeliver(sbm.senderRank,sbm.sessionMsg);
+            auto sbm {deserializeStruct<StructBroadcastMessage>(std::move(msgString))};
+            getSession()->callbackDeliver(sbm.senderRank,std::move(sbm.sessionMsg));
             break;
         }
         default:

--- a/Sources/AlgoLayer/SequencerAlgoLayer/SequencerAlgoLayer.h
+++ b/Sources/AlgoLayer/SequencerAlgoLayer/SequencerAlgoLayer.h
@@ -15,7 +15,7 @@ private:
     std::unique_ptr<CommPeer> sequencerPeer;
 
 public:
-    bool callbackHandleMessage(std::unique_ptr<CommPeer> peer, const std::string &msgString) override;
+    bool callbackHandleMessage(std::unique_ptr<CommPeer> peer, std::string && msgString) override;
     bool executeAndProducedStatistics() override;
     void totalOrderBroadcast(std::string && msg) override;
     void terminate() override;

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -28,7 +28,9 @@ add_executable(fbae
         CommLayer/TcpCommLayer/TcpCommLayer.h
         CommLayer/TcpCommLayer/TcpCommPeer.cpp
         CommLayer/TcpCommLayer/TcpCommPeer.h
-        basicTypes.h)
+        basicTypes.h
+        get_cpu_time.cpp
+        get_cpu_time.h)
 target_link_libraries(fbae PUBLIC enet)
 if (WIN32)
   target_link_libraries(fbae PUBLIC ws2_32.lib winmm.lib)

--- a/Sources/CommLayer/TcpCommLayer/TcpCommLayer.cpp
+++ b/Sources/CommLayer/TcpCommLayer/TcpCommLayer.cpp
@@ -125,7 +125,7 @@ void TcpCommLayer::handleIncomingConn(std::unique_ptr<boost::asio::ip::tcp::sock
             std::scoped_lock lock(mtxCallbackHandleMessage);
             getAlgoLayer()->callbackHandleMessage(
                     make_unique<TcpCommPeer>(ptrSock.get()),
-                    s);
+                    std::move(s));
         }
     }
     catch (boost::system::system_error& e)
@@ -158,7 +158,7 @@ void TcpCommLayer::handleOutgoingConn(std::unique_ptr<boost::asio::ip::tcp::sock
         {
             auto s{receiveEvent(ptrSock.get())};
             std::scoped_lock lock(mtxCallbackHandleMessage);
-            if (getAlgoLayer()->callbackHandleMessage(make_unique<TcpCommPeer>(ptrSock.get()), s))
+            if (getAlgoLayer()->callbackHandleMessage(make_unique<TcpCommPeer>(ptrSock.get()), std::move(s)))
                 break;
         }
     }

--- a/Sources/CommLayer/TcpCommLayer/TcpCommLayer.cpp
+++ b/Sources/CommLayer/TcpCommLayer/TcpCommLayer.cpp
@@ -23,12 +23,12 @@ constexpr int nbTcpConnectTentatives{20};
 constexpr chrono::duration durationBetweenTcpConnectTentatives{500ms};
 
 void TcpCommLayer::acceptConn(int port, size_t nbAwaitedConnections) {
-    std::vector<std::thread> threadsHandleConn(nbAwaitedConnections);
+    std::vector<std::future<void>> tasksHandleConn(nbAwaitedConnections);
     try
     {
         tcp::acceptor a(ioService, tcp::endpoint(tcp::v4(), static_cast<unsigned short>(port)));
 
-        for (auto &t : threadsHandleConn)
+        for (auto &t : tasksHandleConn)
         {
             auto ptrSock = make_unique<tcp::socket>(ioService);
             a.accept(*ptrSock);
@@ -36,7 +36,7 @@ void TcpCommLayer::acceptConn(int port, size_t nbAwaitedConnections) {
             boost::asio::ip::tcp::no_delay option(true);
             ptrSock->set_option(option);
 
-            t = thread(&TcpCommLayer::handleIncomingConn, this, std::move(ptrSock));
+            t = std::async(std::launch::async, &TcpCommLayer::handleIncomingConn, this, std::move(ptrSock));
         }
     }
     catch (boost::system::system_error& e)
@@ -44,11 +44,11 @@ void TcpCommLayer::acceptConn(int port, size_t nbAwaitedConnections) {
         if (e.code() == boost::asio::error::address_in_use)
             cerr << "ERROR: Server cannot bind to port " << port << " (probably because there is an other server running and already bound to this port)\n";
         else
-            cerr << "ERROR: Unexpected Boost Exception in thread acceptConn: " << e.what() << "\n";
+            cerr << "ERROR: Unexpected Boost Exception in task acceptConn: " << e.what() << "\n";
         exit(1);
     }
-    for (auto &t : threadsHandleConn) {
-        t.join();
+    for (auto &t : tasksHandleConn) {
+        t.get();
     }
 }
 
@@ -102,7 +102,7 @@ std::unique_ptr<CommPeer> TcpCommLayer::connectToHost(HostTuple host, AlgoLayer 
         if (ptrSock != nullptr)
         {
             auto peer = make_unique<TcpCommPeer>(ptrSock.get());
-            threadsToJoin.emplace_back(&TcpCommLayer::handleOutgoingConn, this, std::move(ptrSock));
+            tasksToJoin.emplace_back(std::async(std::launch::async, &TcpCommLayer::handleOutgoingConn, this, std::move(ptrSock)));
             return peer;
         }
         this_thread::sleep_for(durationBetweenTcpConnectTentatives);
@@ -145,7 +145,7 @@ void TcpCommLayer::handleIncomingConn(std::unique_ptr<boost::asio::ip::tcp::sock
         }
         else
         {
-            cerr << "ERROR: Unexpected Boost Exception in thread handleIncomingConn: " << e.what() << "\n";
+            cerr << "ERROR: Unexpected Boost Exception in task handleIncomingConn: " << e.what() << "\n";
             exit(1);
         }
     }
@@ -170,7 +170,7 @@ void TcpCommLayer::handleOutgoingConn(std::unique_ptr<boost::asio::ip::tcp::sock
             //  - boost::asio::error::connection_reset for Windows
             cerr << "ERROR: Server has disconnected (probably because it crashed)\n";
         else
-            cerr << "ERROR: Unexpected Boost Exception in thread handleOutgoingConn: " << e.what() << "\n";
+            cerr << "ERROR: Unexpected Boost Exception in task handleOutgoingConn: " << e.what() << "\n";
         exit(1);
     }
 }
@@ -178,7 +178,7 @@ void TcpCommLayer::handleOutgoingConn(std::unique_ptr<boost::asio::ip::tcp::sock
 void TcpCommLayer::initHost(int port, size_t nbAwaitedConnections, AlgoLayer *aAlgoLayer)
 {
     setAlgoLayer(aAlgoLayer);
-    threadsToJoin.emplace_back(&TcpCommLayer::acceptConn, this, port, nbAwaitedConnections);
+    tasksToJoin.emplace_back(std::async(std::launch::async, &TcpCommLayer::acceptConn, this, port, nbAwaitedConnections));
 }
 
 std::string TcpCommLayer::receiveEvent(boost::asio::ip::tcp::socket *ptrSock)
@@ -203,10 +203,10 @@ std::string TcpCommLayer::toString() {
 }
 
 void TcpCommLayer::waitForMsg(size_t maxDisconnections) {
-    // In TcpCommLayer, messages are received by handleIncomingConn and handleOutgoingConn threads.
-    // So we only have to wait for all these threads to die (Note: handleOutgoing threads are watched out by acceptConn
-    // thread ==> We only have to wait for acceptConn thread to die).
-    for (auto &t : threadsToJoin) {
-        t.join();
+    // In TcpCommLayer, messages are received by handleIncomingConn and handleOutgoingConn tasks.
+    // So we only have to wait for all these tasks to die (Note: handleOutgoing tasks are watched out by acceptConn
+    // task ==> We only have to wait for acceptConn task to die).
+    for (auto &t : tasksToJoin) {
+        t.get();
     }
 }

--- a/Sources/CommLayer/TcpCommLayer/TcpCommLayer.h
+++ b/Sources/CommLayer/TcpCommLayer/TcpCommLayer.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include "boost/asio.hpp"
+#include <future>
 #include <mutex>
 #include <shared_mutex>
-#include <thread>
 #include "../CommLayer.h"
 #include "../../Param.h"
 #include "TcpCommPeer.h"
@@ -34,9 +34,9 @@ private:
      */
     std::shared_timed_mutex rwMtxIncomingPeers;
     /**
-     * @brief Threads created by TcpCommLayer which must be joined before existing an instance of TcpCommLayer
+     * @brief Tasks created by TcpCommLayer which must be joined before existing an instance of TcpCommLayer
      */
-    std::vector<std::thread> threadsToJoin;
+    std::vector<std::future<void>> tasksToJoin;
 
     /**
      * @brief Thread for accepting @nbAwaitedConnections connections on port @port

--- a/Sources/Measures.cpp
+++ b/Sources/Measures.cpp
@@ -17,7 +17,7 @@ void Measures::add(std::chrono::duration<double, std::milli> const& elapsed)
 
 std::string Measures::csvHeadline()
 {
-    return std::string { "nbPing,Average (in ms),Min,Q(0.25),Q(0.5),Q(0.75),Q(0.99),Q(0.999),Q(0.9999),Max,Elapsed time (in sec),Throughput (in Mbps)"};
+    return std::string { "nbPing,Average (in ms),Min,Q(0.25),Q(0.5),Q(0.75),Q(0.99),Q(0.999),Q(0.9999),Max,Elapsed time (in sec),CPU time (in sec),Throughput (in Mbps)"};
 }
 
 std::string Measures::asCsv(int argSizeMsg)
@@ -34,6 +34,8 @@ std::string Measures::asCsv(int argSizeMsg)
     constexpr int nbBitsPerByte{ 8 };
     constexpr int nbBitsPerMega{ 1000000 };
     constexpr double nbMillisecondsPerSecond{ 1000.0};
+    constexpr double nbMicrosecondsPerSecond{ 1000000.0};
+
     auto mbps = nbMsgPerPing * static_cast<double>(pings.size()) * argSizeMsg * nbBitsPerByte
                        / (static_cast<double>(duration.count()) / nbMillisecondsPerSecond)
                        / nbBitsPerMega;
@@ -50,14 +52,17 @@ std::string Measures::asCsv(int argSizeMsg)
             + std::to_string(pings[pings.size() * 9999 / 10000].count()) + ","
             + std::to_string(pings[pings.size() - 1].count()) + ","
             + std::to_string(static_cast<double>(duration.count()) / nbMillisecondsPerSecond) + ","
+            + std::to_string((stopTimeCpu - startTimeCpu) / nbMicrosecondsPerSecond) + ","
             + std::to_string(mbps)
     };
 }
 
 void Measures::setStartTime() {
     startTime = std::chrono::system_clock::now();
+    startTimeCpu = get_cpu_time();
 }
 
 void Measures::setStopTime() {
     stopTime = std::chrono::system_clock::now();
+    stopTimeCpu = get_cpu_time();
 }

--- a/Sources/Measures.h
+++ b/Sources/Measures.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <string>
 #include <vector>
+#include "get_cpu_time.h"
 
 class Measures {
 public:
@@ -17,4 +18,6 @@ private:
     std::atomic_size_t nbPing{0};
     std::chrono::time_point<std::chrono::system_clock> startTime;
     std::chrono::time_point<std::chrono::system_clock> stopTime;
+    unsigned long long startTimeCpu;
+    unsigned long long stopTimeCpu;
 };

--- a/Sources/Param.cpp
+++ b/Sources/Param.cpp
@@ -60,7 +60,7 @@ Param::Param(mlib::OptParserExtended const& parser)
     }
 
     // Check that rank value is consistent with contents of site file
-    if ((rank != specialRankToRequestExecutionInThreads) && (rank > sites.size() - 1))
+    if ((rank != specialRankToRequestExecutionInTasks) && (rank > sites.size() - 1))
     {
         std::cerr << "ERROR: You specifed a rank of " << rank << ", but there are only " << sites.size() << " sites specified in JSON file \"" << siteFile << "\"\n"
                 << parser.synopsis () << std::endl;

--- a/Sources/Param.h
+++ b/Sources/Param.h
@@ -11,7 +11,7 @@ constexpr int minSizeClientMessageToBroadcast{22};
 // Maximum length of a UDP packet
 constexpr size_t maxLength{65515};
 
-constexpr int specialRankToRequestExecutionInThreads{99};
+constexpr int specialRankToRequestExecutionInTasks{99};
 
 using HostTuple = std::tuple<std::string, int>;
 

--- a/Sources/SessionLayer/SessionLayer.h
+++ b/Sources/SessionLayer/SessionLayer.h
@@ -42,14 +42,14 @@ private:
      * @param senderRank Rank of message sender.
      * @param msg Message to process.
      */
-    void processPerfMeasureMsg(rank_t senderRank, const std::string &msg);
+    void processPerfMeasureMsg(rank_t senderRank, std::string && msg);
 
     /**
      * @brief Called by @callbackDeliver to process @PerfMeasure message
      * @param senderRank Rank of message sender.
      * @param msg Message to process.
      */
-    void processPerfResponseMsg(rank_t senderRank, const std::string &msg);
+    void processPerfResponseMsg(rank_t senderRank, std::string && msg);
 
     /**
      * @brief Thread to send PerfMessage at @Param::frequency per second.
@@ -65,7 +65,7 @@ public:
      * @param seqNum Sequence number of @msg.
      * @param msg Message to be delivered.
      */
-    void callbackDeliver(rank_t senderRank, const std::string &msg);
+    void callbackDeliver(rank_t senderRank, std::string && msg);
 
     /**
      * @brief Callback called by @AlgoLayer when @AlgoLayer is initialized locally.

--- a/Sources/get_cpu_time.cpp
+++ b/Sources/get_cpu_time.cpp
@@ -1,0 +1,35 @@
+#include "get_cpu_time.h"
+
+// Code adapted from https://stackoverflow.com/questions/17432502/how-can-i-measure-cpu-time-and-wall-clock-time-on-both-linux-windows/17440673#17440673
+
+//  Windows
+#ifdef _WIN32 // A 32-bit platform. This value is also defined by the 64-bit compiler for backward compatibility.
+              // (see https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/64-bit-compiler)
+#include <Windows.h>
+
+// WARNING: Under Windows, you must have a different an elapsed time of at least 100 milliseconds,
+//          otherwaise values returned by get_cpu_time() are not precise enough.
+unsigned long long get_cpu_time(){
+    FILETIME start, exit, kernel, user;
+    if (GetProcessTimes(GetCurrentProcess(),&start,&exit,&kernel,&user) != 0){
+        //  Returns total kernel and user time.
+        return
+            ((kernel.dwLowDateTime |
+                (unsigned long long)kernel.dwHighDateTime << 32)
+             + (user.dwLowDateTime |
+                (unsigned long long)user.dwHighDateTime << 32)) / 10;
+    }else{
+        //  Handle error
+        return 0;
+    }
+}
+
+//  Posix/Linux
+#else
+#include <time.h>
+#include <sys/time.h>
+
+unsigned long long get_cpu_time(){
+    return (unsigned long long)clock();
+}
+#endif

--- a/Sources/get_cpu_time.h
+++ b/Sources/get_cpu_time.h
@@ -1,0 +1,12 @@
+#ifndef _GET_CPU_TIME_H
+#define _GET_CPU_TIME_H
+
+/**
+ * @brief Returns CPU time (in microseconds).
+ * Note: Under Windows, you must have a different an elapsed time of at least 100 milliseconds,
+ *       Otherwise values returned by get_cpu_time() are not precise enough.
+ * @return CPU time (in microseconds)
+ */
+unsigned long long get_cpu_time();
+
+#endif /* _GET_CPU_TIME_H */

--- a/Sources/msgTemplates.h
+++ b/Sources/msgTemplates.h
@@ -12,7 +12,7 @@
  * @return Structure deserialized from @msgString
  */
 template <typename S>
-S deserializeStruct(const std::string &msgString)
+S deserializeStruct(std::string && msgString)
 {
     std::istringstream msgStream{msgString};
     cereal::BinaryInputArchive archive(msgStream); // Create an input archive

--- a/Sources/msgTemplates.h
+++ b/Sources/msgTemplates.h
@@ -14,7 +14,7 @@
 template <typename S>
 S deserializeStruct(std::string && msgString)
 {
-    std::istringstream msgStream{msgString};
+    std::istringstream msgStream{std::move(msgString)};
     cereal::BinaryInputArchive archive(msgStream); // Create an input archive
     S structure{};
     archive(structure); // Read the structure from the archive


### PR DESCRIPTION
In addition to using tasks instead of threads, we took car of the following problems/additions :

- Use std::move to process messages going from CommLayer to SessionLayer
- Use std::move in deserializeStruct to reduce memory allocations. For both of these improvements, tests made with valgrind show (`valgrind ./fbae -a B -c t -f 100 -n 500 -r 99 -s 1024 -S ../../Resources/sites_3_local.json`) show that heap summary
    - goes from ``total heap usage: 72,899 allocs, 72,899 frees, 136,927,427 bytes allocated`
    - to `total heap usage: 60,288 allocs, 60,288 frees, 116,008,901 bytes allocated` 
- Add CPU time to displayed statistics

Here is an example of displayed statistics (Note how CPU time is ~3 times elapsed time):

```
$ ./fbae -a B -c t -f 100 -n 200 -r 99 -s 1024 -S ../../Resources/s
ites_3_local.json
algoLayer,commLayer,frequency,maxBatchSize,nbMsg,rank,sizeMsg,siteFile,nbPing,Average (in ms),Min,Q(0.25),Q(0.5),Q(0.75),Q(0.99),Q(0.999),Q(0.9999),Max,Elapsed time (in sec),CPU time (in sec),Throughput (in Mbps)
BBOBB,TCP,100,2147483647,200,2,1024,../../Resources/sites_3_local.json,200,5.579713,1.265608,3.825757,5.078139,8.002311,8.545131,8.563862,8.563862,8.563862,1.008000,2.835699,3.250794
algoLayer,commLayer,frequency,maxBatchSize,nbMsg,rank,sizeMsg,siteFile,nbPing,Average (in ms),Min,Q(0.25),Q(0.5),Q(0.75),Q(0.99),Q(0.999),Q(0.9999),Max,Elapsed time (in sec),CPU time (in sec),Throughput (in Mbps)
BBOBB,TCP,100,2147483647,200,1,1024,../../Resources/sites_3_local.json,200,5.971380,2.818520,4.546593,5.837990,7.909969,8.428919,8.449592,8.449592,8.449592,1.009000,2.836374,3.247572
algoLayer,commLayer,frequency,maxBatchSize,nbMsg,rank,sizeMsg,siteFile,nbPing,Average (in ms),Min,Q(0.25),Q(0.5),Q(0.75),Q(0.99),Q(0.999),Q(0.9999),Max,Elapsed time (in sec),CPU time (in sec),Throughput (in Mbps)
BBOBB,TCP,100,2147483647,200,0,1024,../../Resources/sites_3_local.json,200,4.902829,1.770084,2.579765,2.873854,7.802986,8.354538,8.381707,8.381707,8.381707,1.002000,2.819452,3.270259
```