### PR TITLE
Add -w/warmupCooldown argument and use it to manage percentage of messages in warmup/cool down phase

### DIFF
--- a/Sources/Param.cpp
+++ b/Sources/Param.cpp
@@ -32,6 +32,16 @@ Param::Param(mlib::OptParserExtended const& parser)
         }
     }
 
+    if (parser.hasopt('w')) {
+        warmupCooldown = parser.getoptIntRequired('w');
+        if (warmupCooldown > 99) {
+            std::cerr << "ERROR: Argument for warmupCooldown must be in [0,99]"
+                      << std::endl
+                      << parser.synopsis () << std::endl;
+            exit(EXIT_FAILURE);
+        }
+    }
+
     if (sizeMsg < minSizeClientMessageToBroadcast || sizeMsg > maxLength)
     {
         std::cerr << "ERROR: Argument for size of messages is " << sizeMsg
@@ -71,12 +81,21 @@ Param::Param(mlib::OptParserExtended const& parser)
 [[nodiscard]] std::string
 Param::asCsv(std::string const &algoStr, std::string const &commLayerStr, std::string const &rankStr) const
 {
-    return std::string { algoStr + "," + commLayerStr + "," + std::to_string(frequency) + "," + std::to_string(maxBatchSize) + "," + std::to_string(nbMsg) + "," + rankStr  + "," + std::to_string(sizeMsg) + "," + siteFile};
+    return std::string {
+        algoStr + ","
+        + commLayerStr + ","
+        + std::to_string(frequency) + ","
+        + std::to_string(maxBatchSize) + ","
+        + std::to_string(nbMsg) + ","
+        + std::to_string(warmupCooldown) + "%,"
+        + rankStr  + ","
+        + std::to_string(sizeMsg) + ","
+        + siteFile};
 }
 
 std::string Param::csvHeadline()
 {
-    return std::string { "algoLayer,commLayer,frequency,maxBatchSize,nbMsg,rank,sizeMsg,siteFile"};
+    return std::string { "algoLayer,commLayer,frequency,maxBatchSize,nbMsg,warmupCooldown,rank,sizeMsg,siteFile"};
 }
 
 int Param::getFrequency() const {
@@ -87,7 +106,7 @@ int Param::getMaxBatchSize() const {
     return maxBatchSize;
 }
 
-int Param::getNbMsg() const {
+int64_t Param::getNbMsg() const {
     return nbMsg;
 }
 
@@ -106,5 +125,9 @@ int Param::getSizeMsg() const {
 }
 bool Param::getVerbose() const {
     return verbose;
+}
+
+int Param::getWarmupCooldown() const {
+    return warmupCooldown;
 }
 

--- a/Sources/Param.h
+++ b/Sources/Param.h
@@ -23,12 +23,13 @@ class Param {
 private:
     int frequency{0};
     int maxBatchSize{INT32_MAX};
-    int nbMsg{0};
+    int64_t nbMsg{0};
     uint8_t rank{0};
     int sizeMsg{0};
     std::string siteFile{};
     std::vector<HostTuple> sites;
     bool verbose{false};
+    int warmupCooldown{0};
 
 public:
     explicit Param(mlib::OptParserExtended const& parser);
@@ -37,10 +38,11 @@ public:
     static std::string csvHeadline();
     [[nodiscard]] int getFrequency() const;
     [[nodiscard]] int getMaxBatchSize() const;
-    [[nodiscard]] int getNbMsg() const;
+    [[nodiscard]] int64_t getNbMsg() const;
     [[nodiscard]] uint8_t getRank() const;
     [[nodiscard]] std::vector<HostTuple> getSites() const;
     [[nodiscard]] int getSizeMsg() const;
     [[nodiscard]] bool getVerbose() const;
+    [[nodiscard]] int getWarmupCooldown() const;
 };
 

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -57,7 +57,8 @@ int main(int argc, char* argv[])
             "r:rank rank_number \t Rank of process in site file (if 99, all algorithm participants are executed within threads in current process)",
             "s:size size_in_bytes \t Size of messages sent by a client (must be in interval [22,65515])",
             "S:site siteFile_name \t Name (including path) of the sites file to be used",
-            "v|verbose \t [optional] Verbose display required"
+            "v|verbose \t [optional] Verbose display required",
+            "w:warmupCooldown number \t [optional] Number in [0,99] representing percentage of PerfMessage session messages which will be considered as part of warmup phase or cool down phase and thus will not be measured for ping (By default, percentage is 0%)"
     };
 
     int nonopt;


### PR DESCRIPTION
Implements -w argument which specifies percentage of PerfMessage messages in warmup phase and also in cooldown phase. In other words, percentage of messages in warmup phase is **half** of the percentage specified with this argument (and the same holds for percentage f messages in cool down phase.