### PR TITLE
Improve test to reach desired frequency of sent PerfMessage when using -f argument

### DIFF
--- a/Sources/Measures.cpp
+++ b/Sources/Measures.cpp
@@ -32,9 +32,9 @@ std::string Measures::asCsv(int argSizeMsg)
 
     constexpr int nbMsgPerPing{ 2 };
     constexpr int nbBitsPerByte{ 8 };
-    constexpr int nbBitsPerMega{ 1000000 };
-    constexpr double nbMillisecondsPerSecond{ 1000.0};
-    constexpr double nbMicrosecondsPerSecond{ 1000000.0};
+    constexpr int nbBitsPerMega{ 1'000'000 };
+    constexpr double nbMillisecondsPerSecond{ 1'000.0};
+    constexpr double nbMicrosecondsPerSecond{ 1'000'000.0};
 
     auto mbps = nbMsgPerPing * static_cast<double>(pings.size()) * argSizeMsg * nbBitsPerByte
                        / (static_cast<double>(duration.count()) / nbMillisecondsPerSecond)
@@ -48,8 +48,8 @@ std::string Measures::asCsv(int argSizeMsg)
             + std::to_string(pings[pings.size() / 2].count()) + ","
             + std::to_string(pings[pings.size() * 3 / 4].count()) + ","
             + std::to_string(pings[pings.size() * 99 / 100].count()) + ","
-            + std::to_string(pings[pings.size() * 999 / 1000].count()) + ","
-            + std::to_string(pings[pings.size() * 9999 / 10000].count()) + ","
+            + std::to_string(pings[pings.size() * 999 / 1'000].count()) + ","
+            + std::to_string(pings[pings.size() * 9999 / 10'000].count()) + ","
             + std::to_string(pings[pings.size() - 1].count()) + ","
             + std::to_string(static_cast<double>(duration.count()) / nbMillisecondsPerSecond) + ","
             + std::to_string((stopTimeCpu - startTimeCpu) / nbMicrosecondsPerSecond) + ","

--- a/Sources/SessionLayer/SessionLayer.cpp
+++ b/Sources/SessionLayer/SessionLayer.cpp
@@ -202,12 +202,13 @@ void SessionLayer::processPerfResponseMsg(rank_t senderRank, std::string && msg)
 void SessionLayer::sendPeriodicPerfMessage() {
     okToSendPeriodicPerfMessage.wait();
     constexpr std::chrono::duration<double, std::milli> sleepDuration{5ms};
+    constexpr double nbMillisecondsPerSecond{ 1'000.0 };
     const auto freq{ param.getFrequency() };
     auto startSending{ std::chrono::system_clock::now() };
     while(true) {
-        auto elapsedPeriod{ std::chrono::system_clock::now() - startSending };
+        auto elapsedPeriod{ duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - startSending) };
         // Broadcast PerfMeasure messages until we reach the desired frequency
-        while (numPerfMeasure < freq * static_cast<double>(elapsedPeriod / 1000ms)) {
+        while (numPerfMeasure < freq * static_cast<double>(elapsedPeriod.count()) / nbMillisecondsPerSecond) {
             broadcastPerfMeasure();
             if (numPerfMeasure >= param.getNbMsg())
                 return;


### PR DESCRIPTION
Test ` ./fbae -a B -c t -f 1000 -n 5000 -r 99 -s 1024 -S ../../Resources/sites_3_local.json -w 10` show that elapsed time is now `4.496000` seconds. When running fbae on 8 different machines, we get an elapsed time of `4.500000` seconds.