### PR TITLE
Suppress SonarLint warning about parameter in Tcp::send()

### DIFF
--- a/Sources/AlgoLayer/Sequencer/Sequencer.cpp
+++ b/Sources/AlgoLayer/Sequencer/Sequencer.cpp
@@ -23,7 +23,7 @@ void Sequencer::callbackHandleMessage(std::string && msgString)
             auto s {serializeStruct<StructBroadcastMessage>(StructBroadcastMessage{MsgId::Broadcast,
                                                                                    msgToBroadcast.senderPos,
                                                                                    msgToBroadcast.sessionMsg})};
-            getSession()->getCommLayer()->multicastMsg(std::move(s));
+            getSession()->getCommLayer()->multicastMsg(s);
             break;
         }
         //
@@ -86,5 +86,5 @@ void Sequencer::totalOrderBroadcast(std::string && msg) {
     auto s {serializeStruct<StructBroadcastMessage>(StructBroadcastMessage{MsgId::BroadcastRequest,
                                                                            getPosInBroadcasters(),
                                                                                std::move(msg)})};
-    getSession()->getCommLayer()->send(sequencerRank, std::move(s));
+    getSession()->getCommLayer()->send(sequencerRank, s);
 }

--- a/Sources/CommLayer/CommLayer.h
+++ b/Sources/CommLayer/CommLayer.h
@@ -12,13 +12,6 @@ public:
     virtual ~CommLayer() = default;
 
     /**
-     * @brief Multicast message contained in @msg to all peer which the process connected to (Note: The peers which
-     * connected to the process are not concerned by this multicast)
-     * @param msg Message to be totalOrderBroadcast
-     */
-    virtual void multicastMsg(std::string && msg) = 0;
-
-    /**
      * @brief Getter for @algoLayer.
      * @return @algoLayer.
      */
@@ -29,6 +22,13 @@ public:
      * @return @commLayerReady
      */
     [[nodiscard]] std::latch &getInitDoneCalled();
+
+    /**
+     * @brief Multicast message contained in @msg to all peer which the process connected to (Note: The peers which
+     * connected to the process are not concerned by this multicast)
+     * @param msg Message to be totalOrderBroadcast
+     */
+    virtual void multicastMsg(const std::string &msg) = 0;
 
     /**
      * @brief Open connection to peers (named outgoing peers) which rank is listed in @dest, accepts
@@ -51,7 +51,7 @@ public:
      * @param r Rank of outgoing peer
      * @param msg Message to send.
      */
-    virtual void send(rank_t r, std::string && msg) = 0;
+    virtual void send(rank_t r, const std::string &msg) = 0;
 
     /**
      * @brief CommLayer must close all of its connections

--- a/Sources/CommLayer/Tcp/Tcp.cpp
+++ b/Sources/CommLayer/Tcp/Tcp.cpp
@@ -100,10 +100,10 @@ void Tcp::handleIncomingConn(std::unique_ptr<boost::asio::ip::tcp::socket> ptrSo
     }
 }
 
-void Tcp::multicastMsg(std::string && msg)
+void Tcp::multicastMsg(const std::string &msg)
 {
     for (auto const& [r, sock]: rank2sock) {
-        send(r, std::move(msg));
+        send(r, msg);
     }
 }
 
@@ -156,7 +156,7 @@ struct ForLength
     }
 };
 
-void Tcp::send(rank_t r, string &&msg) {
+void Tcp::send(rank_t r, const std::string &msg) {
     assert(rank2sock.contains(r));
     ForLength forLength{msg.length()};
     std::stringstream oStream;
@@ -168,7 +168,7 @@ void Tcp::send(rank_t r, string &&msg) {
     auto sWithLength = oStream.str();
     sWithLength.append(msg);
 
-    boost::asio::write(*rank2sock[r], boost::asio::buffer(sWithLength.data(), sWithLength.length()));
+    boost::asio::write(*rank2sock[r], boost::asio::buffer(sWithLength));
 }
 
 void Tcp::terminate() {

--- a/Sources/CommLayer/Tcp/Tcp.h
+++ b/Sources/CommLayer/Tcp/Tcp.h
@@ -15,9 +15,9 @@
 class Tcp : public CommLayer{
 public:
     Tcp() = default;
-    void multicastMsg(std::string && msg) override;
+    void multicastMsg(const std::string &msg) override;
     void openDestAndWaitIncomingMsg(std::vector<rank_t> const & dest, size_t nbAwaitedConnections, AlgoLayer *aAlgoLayer) override;
-    void send(rank_t r, std::string && msg) override;
+    void send(rank_t r, const std::string &msg) override;
     void terminate() override;
     std::string toString() override;
 

--- a/Sources/Param.cpp
+++ b/Sources/Param.cpp
@@ -7,7 +7,7 @@
 
 Param::Param(mlib::OptParserExtended const& parser)
 : nbMsg{parser.getoptIntRequired('n')}
-, rank{static_cast<uint8_t>(parser.getoptIntRequired('r'))}
+, rank{static_cast<rank_t>(parser.getoptIntRequired('r'))}
 , sizeMsg{parser.getoptIntRequired('s')}
 , siteFile{parser.getoptStringRequired('S')}
 , verbose{parser.hasopt ('v')}
@@ -110,7 +110,7 @@ int64_t Param::getNbMsg() const {
     return nbMsg;
 }
 
-uint8_t Param::getRank() const
+rank_t Param::getRank() const
 {
     return rank;
 }

--- a/Sources/Param.h
+++ b/Sources/Param.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include "basicTypes.h"
 #include "OptParserExtended.h"
 
 // The following value has been found experimentally when filler field of SenderMessageToBroadcast has size 0
@@ -24,7 +25,7 @@ private:
     int frequency{0};
     int maxBatchSize{INT32_MAX};
     int64_t nbMsg{0};
-    uint8_t rank{0};
+    rank_t rank{0};
     int sizeMsg{0};
     std::string siteFile{};
     std::vector<HostTuple> sites;
@@ -39,7 +40,7 @@ public:
     [[nodiscard]] int getFrequency() const;
     [[nodiscard]] int getMaxBatchSize() const;
     [[nodiscard]] int64_t getNbMsg() const;
-    [[nodiscard]] uint8_t getRank() const;
+    [[nodiscard]] rank_t getRank() const;
     [[nodiscard]] std::vector<HostTuple> getSites() const;
     [[nodiscard]] int getSizeMsg() const;
     [[nodiscard]] bool getVerbose() const;

--- a/Sources/SessionLayer/Session/Session.h
+++ b/Sources/SessionLayer/Session/Session.h
@@ -5,7 +5,7 @@
 #ifndef FBAE_SESSION_H
 #define FBAE_SESSION_H
 
-#include <latch>
+#include <future>
 #include <memory>
 #include "../SessionLayer.h"
 #include "../../Measures.h"
@@ -32,7 +32,7 @@ private:
     int32_t nbReceivedPerfResponseForSelf{0};
     size_t nbReceivedFirstBroadcast{0};
     size_t nbReceivedFinishedPerfMeasures{0};
-    std::latch okToSendPeriodicPerfMessage{1};
+    std::future<void> taskSendPeriodicPerfMessage;
 
     /**
      * @brief Broadcasts a @PerfMeasure message with @msgNum incremented by 1.


### PR DESCRIPTION
Correct bug preventing -f argument to be taken into account Use rank_t type in Param class